### PR TITLE
issue#76 [fix] エラー解決のためcalendar.jsを修正

### DIFF
--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -2,15 +2,20 @@ import '@fullcalendar/core/vdom'; // for Vite
 import { Calendar } from "@fullcalendar/core";
 import dayGridPlugin from "@fullcalendar/daygrid";
 
-var calendarEl = document.getElementById("calendar");
+var calendar;
+let calendarEl = document.getElementById("calendar");
 
-let calendar = new Calendar(calendarEl, {
-    plugins: [dayGridPlugin],
-    initialView: "dayGridMonth",
-    headerToolbar: {
-        left: "prev,next today",
-        center: "title",
-        right: "",
-    },
-});
-calendar.render();
+// Cannot read property '__k' of nullエラーを避けるため
+// 下のif文を追加。calendarElがnullでなけらばif文の中実行。
+if (calendarEl != null) {
+    let calendar = new Calendar(calendarEl, {
+        plugins: [dayGridPlugin],
+        initialView: "dayGridMonth",
+        headerToolbar: {
+            left: "prev,next today",
+            center: "title",
+            right: "",
+        },
+    });
+    calendar.render();
+}


### PR DESCRIPTION
Close #76 
FullCalendarに起因した以下のエラーの解決

[Cannot read property '__k' of null](https://stackoverflow.com/questions/67545822/cannot-read-property-k-of-null-fullcalendar-angular-11)


参考にした記事
https://stackoverflow.com/questions/67545822/cannot-read-property-k-of-null-fullcalendar-angular-11

